### PR TITLE
A more realistic duration

### DIFF
--- a/onelogin.sdk.json.template
+++ b/onelogin.sdk.json.template
@@ -6,5 +6,6 @@
   "app_id": "",
   "subdomain": "",
   "username": "",
-  "profile": ""
+  "profile": "",
+  "duration": 28800
 }

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -113,6 +113,8 @@ def get_options():
         options.username = config['username']
     if 'profile' in config.keys():
         options.profile_name = config['profile']
+    if 'duration' in config.keys():
+        options.duration = config['duration']
 
     return options
 


### PR DESCRIPTION
Being the lazy person that I am, and to match with what has already been configured on our AWS account per SecEng, let's set the duration in seconds to be passed from our config file rather than using defaults or continually having to pass the `-Z` CLI option